### PR TITLE
Fix Decode TGChatMember

### DIFF
--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberAdministrator.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberAdministrator.swift
@@ -109,4 +109,38 @@ public final class TGChatMemberAdministrator: Codable {
         self.canManageTopics = canManageTopics
         self.customTitle = customTitle
     }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(String.self, forKey: .status)
+        guard status == "administrator" else {
+            throw DecodingError
+                .dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Wrong status value"
+                    )
+                )
+        }
+        self.status = status
+        self.user = try container.decode(TGUser.self, forKey: .user)
+        self.canBeEdited = try container.decode(Bool.self, forKey: .canBeEdited)
+        self.isAnonymous = try container.decode(Bool.self, forKey: .isAnonymous)
+        self.canManageChat = try container.decode(Bool.self, forKey: .canManageChat)
+        self.canDeleteMessages = try container.decode(Bool.self, forKey: .canDeleteMessages)
+        self.canManageVideoChats = try container.decode(Bool.self, forKey: .canManageVideoChats)
+        self.canRestrictMembers = try container.decode(Bool.self, forKey: .canRestrictMembers)
+        self.canPromoteMembers = try container.decode(Bool.self, forKey: .canPromoteMembers)
+        self.canChangeInfo = try container.decode(Bool.self, forKey: .canChangeInfo)
+        self.canInviteUsers = try container.decode(Bool.self, forKey: .canInviteUsers)
+        self.canPostStories = try container.decode(Bool.self, forKey: .canPostStories)
+        self.canEditStories = try container.decode(Bool.self, forKey: .canEditStories)
+        self.canDeleteStories = try container.decode(Bool.self, forKey: .canDeleteStories)
+        self.canPostMessages = try container.decodeIfPresent(Bool.self, forKey: .canPostMessages)
+        self.canEditMessages = try container.decodeIfPresent(Bool.self, forKey: .canEditMessages)
+        self.canPinMessages = try container.decodeIfPresent(Bool.self, forKey: .canPinMessages)
+        self.canManageTopics = try container.decodeIfPresent(Bool.self, forKey: .canManageTopics)
+        self.customTitle = try container.decodeIfPresent(String.self, forKey: .customTitle)
+    }
+
 }

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberBanned.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberBanned.swift
@@ -29,4 +29,22 @@ public final class TGChatMemberBanned: Codable {
         self.user = user
         self.untilDate = untilDate
     }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(String.self, forKey: .status)
+        guard status == "kicked" else {
+            throw DecodingError
+                .dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Wrong status value"
+                    )
+                )
+        }
+        self.status = status
+        self.user = try container.decode(TGUser.self, forKey: .user)
+        self.untilDate = try container.decode(Int.self, forKey: .untilDate)
+    }
+
 }

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberLeft.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberLeft.swift
@@ -24,4 +24,21 @@ public final class TGChatMemberLeft: Codable {
         self.status = status
         self.user = user
     }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(String.self, forKey: .status)
+        guard status == "left" else {
+            throw DecodingError
+                .dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Wrong status value"
+                    )
+                )
+        }
+        self.status = status
+        self.user = try container.decode(TGUser.self, forKey: .user)
+    }
+
 }

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberMember.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberMember.swift
@@ -29,4 +29,22 @@ public final class TGChatMemberMember: Codable {
         self.user = user
         self.untilDate = untilDate
     }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(String.self, forKey: .status)
+        guard status == "member" else {
+            throw DecodingError
+                .dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Wrong status value"
+                    )
+                )
+        }
+        self.status = status
+        self.user = try container.decode(TGUser.self, forKey: .user)
+        self.untilDate = try container.decodeIfPresent(Int.self, forKey: .untilDate)
+    }
+
 }

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberOwner.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberOwner.swift
@@ -34,4 +34,24 @@ public final class TGChatMemberOwner: Codable {
         self.isAnonymous = isAnonymous
         self.customTitle = customTitle
     }
+
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(String.self, forKey: .status)
+        guard status == "creator" else {
+            throw DecodingError
+                .dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Wrong status value"
+                    )
+                )
+        }
+        self.status = status
+        self.user = try container.decode(TGUser.self, forKey: .user)
+        self.isAnonymous = try container.decode(Bool.self, forKey: .isAnonymous)
+        self.customTitle = try container.decodeIfPresent(String.self, forKey: .customTitle)
+    }
+
 }

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberRestricted.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChatMemberRestricted.swift
@@ -104,4 +104,37 @@ public final class TGChatMemberRestricted: Codable {
         self.canManageTopics = canManageTopics
         self.untilDate = untilDate
     }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(String.self, forKey: .status)
+        guard status == "restricted" else {
+            throw DecodingError
+                .dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Wrong status value"
+                    )
+                )
+        }
+        self.status = status
+        self.user = try container.decode(TGUser.self, forKey: .user)
+        self.isMember = try container.decode(Bool.self, forKey: .isMember)
+        self.canSendMessages = try container.decode(Bool.self, forKey: .canSendMessages)
+        self.canSendAudios = try container.decode(Bool.self, forKey: .canSendAudios)
+        self.canSendDocuments = try container.decode(Bool.self, forKey: .canSendDocuments)
+        self.canSendPhotos = try container.decode(Bool.self, forKey: .canSendPhotos)
+        self.canSendVideos = try container.decode(Bool.self, forKey: .canSendVideos)
+        self.canSendVideoNotes = try container.decode(Bool.self, forKey: .canSendVideoNotes)
+        self.canSendVoiceNotes = try container.decode(Bool.self, forKey: .canSendVoiceNotes)
+        self.canSendPolls = try container.decode(Bool.self, forKey: .canSendPolls)
+        self.canSendOtherMessages = try container.decode(Bool.self, forKey: .canSendOtherMessages)
+        self.canAddWebPagePreviews = try container.decode(Bool.self, forKey: .canAddWebPagePreviews)
+        self.canChangeInfo = try container.decode(Bool.self, forKey: .canChangeInfo)
+        self.canInviteUsers = try container.decode(Bool.self, forKey: .canInviteUsers)
+        self.canPinMessages = try container.decode(Bool.self, forKey: .canPinMessages)
+        self.canManageTopics = try container.decode(Bool.self, forKey: .canManageTopics)
+        self.untilDate = try container.decode(Int.self, forKey: .untilDate)
+    }
+
 }


### PR DESCRIPTION
Из-за того, что модельки `ChatMemberMember`, `ChatMemberBanned`, `ChatMemberLeft` практически идентичные, то декодировалась первая попавшаяся в `else if let` в декодере. 

Поэтому, когда ожидаешь:
```swift
if let member = update.chatMember {
    switch (member.oldChatMember, member.newChatMember) {
    case (.chatMemberLeft(let oldUserMember), .chatMemberMember(let newUserMember)):
        try await bot.sendMessage(params: .init(
            chatId: .chat(member.chat.id),
            text: "\(newUserMember.user.firstName) вошёл в чат."
        ))
    }
}
```
Но валидной получается только такая запись:
```swift 
if let member = update.chatMember {
    switch (member.oldChatMember, member.newChatMember) {
    case (.chatMemberMember(let oldUserMember), .chatMemberMember(let newUserMember))
        where oldUserMember.status == "left" && newUserMember.status == "member":
        try await bot.sendMessage(params: .init(
            chatId: .chat(member.chat.id),
            text: "\(newUserMember.user.firstName) вошёл в чат."
        ))
    }
}
 ```