### PR TITLE
Update Models to apply the [latest Bot API Update](https://core.telegram.org/bots/api#july-3-2025) (July 3rd, 2025)

### DIFF
--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Methods/EditMessageChecklist.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Methods/EditMessageChecklist.swift
@@ -1,0 +1,66 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+import Foundation
+
+/// DESCRIPTION:
+/// Use this method to edit a checklist on behalf of a connected business account. On success, the edited Message is returned.
+
+/// Parameters container struct for `editMessageChecklist` method
+public struct TGEditMessageChecklistParams: Encodable {
+    
+    /// Unique identifier of the business connection on behalf of which the message will be sent
+    public var businessConnectionId: String
+    
+    /// Unique identifier for the target chat
+    public var chatId: Int64
+    
+    /// Unique identifier for the target message
+    public var messageId: Int
+    
+    /// A JSON-serialized object for the new checklist
+    public var checklist: TGInputChecklist
+    
+    /// A JSON-serialized object for the new inline keyboard for the message
+    public var replyMarkup: TGInlineKeyboardMarkup?
+
+    /// Custom keys for coding/decoding `TGEditMessageChecklistParams` struct
+    enum CodingKeys: String, CodingKey {
+        case businessConnectionId = "business_connection_id"
+        case chatId = "chat_id"
+        case messageId = "message_id"
+        case checklist
+        case replyMarkup = "reply_markup"
+    }
+
+    public init(businessConnectionId: String, chatId: Int64, messageId: Int, checklist: TGInputChecklist, replyMarkup: TGInlineKeyboardMarkup? = nil) {
+        self.businessConnectionId = businessConnectionId
+        self.chatId = chatId
+        self.messageId = messageId
+        self.checklist = checklist
+        self.replyMarkup = replyMarkup
+    }
+}
+
+public extension TGBot {
+
+/**
+ Use this method to edit a checklist on behalf of a connected business account. On success, the edited Message is returned.
+
+ SeeAlso Telegram Bot API Reference:
+ [EditMessageChecklistParams](https://core.telegram.org/bots/api#editmessagechecklist)
+ 
+ - Parameters:
+     - params: Parameters container, see `TGEditMessageChecklistParams` struct
+ - Throws: Throws on errors
+ - Returns: `TGMessage`
+ */
+
+    @discardableResult
+    func editMessageChecklist(params: TGEditMessageChecklistParams) async throws -> TGMessage {
+        guard let methodURL: URL = .init(string: getMethodURL("editMessageChecklist")) else {
+            throw BotError("Bad URL: \(getMethodURL("editMessageChecklist"))")
+        }
+        let result: TGMessage = try await tgClient.post(methodURL, params: params, as: nil)
+        return result
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Methods/GetMyStarBalance.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Methods/GetMyStarBalance.swift
@@ -1,0 +1,29 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+import Foundation
+
+/// DESCRIPTION:
+/// A method to get the current Telegram Stars balance of the bot. Requires no parameters. On success, returns a StarAmount object.
+
+
+
+public extension TGBot {
+/**
+ A method to get the current Telegram Stars balance of the bot. Requires no parameters. On success, returns a StarAmount object.
+
+ SeeAlso Telegram Bot API Reference:
+ [CloseParams](https://core.telegram.org/bots/api#getmystarbalance)
+ 
+ - Throws: Throws on errors
+ - Returns: `TGStarAmount`
+ */
+
+    @discardableResult
+    func getMyStarBalance() async throws -> TGStarAmount {
+        guard let methodURL: URL = .init(string: getMethodURL("getMyStarBalance")) else {
+            throw BotError("Bad URL: \(getMethodURL("getMyStarBalance"))")
+        }
+        let result: TGStarAmount = try await tgClient.post(methodURL)
+        return result
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Methods/SendChecklist.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Methods/SendChecklist.swift
@@ -1,0 +1,81 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+import Foundation
+
+/// DESCRIPTION:
+/// Use this method to send a checklist on behalf of a connected business account. On success, the sent Message is returned.
+
+/// Parameters container struct for `sendChecklist` method
+public struct TGSendChecklistParams: Encodable {
+    
+    /// Unique identifier of the business connection on behalf of which the message will be sent
+    public var businessConnectionId: String
+    
+    /// Unique identifier for the target chat
+    public var chatId: Int64
+    
+    /// A JSON-serialized object for the checklist to send
+    public var checklist: TGInputChecklist
+    
+    /// Sends the message silently. Users will receive a notification with no sound.
+    public var disableNotification: Bool?
+    
+    /// Protects the contents of the sent message from forwarding and saving
+    public var protectContent: Bool?
+    
+    /// Unique identifier of the message effect to be added to the message
+    public var messageEffectId: String?
+    
+    /// A JSON-serialized object for description of the message to reply to
+    public var replyParameters: TGReplyParameters?
+    
+    /// A JSON-serialized object for an inline keyboard
+    public var replyMarkup: TGInlineKeyboardMarkup?
+
+    /// Custom keys for coding/decoding `TGSendChecklistParams` struct
+    enum CodingKeys: String, CodingKey {
+        case businessConnectionId = "business_connection_id"
+        case chatId = "chat_id"
+        case checklist
+        case disableNotification = "disable_notification"
+        case protectContent = "protect_content"
+        case messageEffectId = "message_effect_id"
+        case replyParameters = "reply_parameters"
+        case replyMarkup = "reply_markup"
+    }
+
+    public init(businessConnectionId: String, chatId: Int64, checklist: TGInputChecklist, disableNotification: Bool? = nil, protectContent: Bool? = nil, messageEffectId: String? = nil, replyParameters: TGReplyParameters? = nil, replyMarkup: TGInlineKeyboardMarkup? = nil) {
+        self.businessConnectionId = businessConnectionId
+        self.chatId = chatId
+        self.checklist = checklist
+        self.disableNotification = disableNotification
+        self.protectContent = protectContent
+        self.messageEffectId = messageEffectId
+        self.replyParameters = replyParameters
+        self.replyMarkup = replyMarkup
+    }
+}
+
+public extension TGBot {
+
+/**
+ Use this method to send a checklist on behalf of a connected business account. On success, the sent Message is returned.
+
+ SeeAlso Telegram Bot API Reference:
+ [SendChecklistParams](https://core.telegram.org/bots/api#sendchecklist)
+ 
+ - Parameters:
+     - params: Parameters container, see `TGSendChecklistParams` struct
+ - Throws: Throws on errors
+ - Returns: `TGMessage`
+ */
+
+    @discardableResult
+    func sendChecklist(params: TGSendChecklistParams) async throws -> TGMessage {
+        guard let methodURL: URL = .init(string: getMethodURL("sendChecklist")) else {
+            throw BotError("Bad URL: \(getMethodURL("sendChecklist"))")
+        }
+        let result: TGMessage = try await tgClient.post(methodURL, params: params, as: nil)
+        return result
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/DirectMessagePriceChanged.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/DirectMessagePriceChanged.swift
@@ -1,0 +1,26 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+/**
+ Describes a service message about a change in the price of direct messages sent to a channel chat.
+
+ SeeAlso Telegram Bot API Reference:
+ [DirectMessagePriceChanged](https://core.telegram.org/bots/api#directmessagepricechanged)
+ */
+
+public final class TGDirectMessagePriceChanged: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case areDirectMessagesEnabled = "are_direct_messages_enabled"
+        case directMessageStarCount = "direct_message_star_count"
+    }
+
+    /// True, if direct messages are enabled for the channel chat; false otherwise
+    public var areDirectMessagesEnabled: Bool
+
+    /// Optional. The new number of Telegram Stars that must be paid by users for each direct message sent to the channel. Does not apply to users who have been exempted by administrators. Defaults to 0.
+    public var directMessageStarCount: Int?
+
+    public init(areDirectMessagesEnabled: Bool, directMessageStarCount: Int? = nil) {
+        self.areDirectMessagesEnabled = areDirectMessagesEnabled
+        self.directMessageStarCount = directMessageStarCount
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklist.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklist.swift
@@ -1,0 +1,41 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+/**
+ Describes a checklist.
+
+ SeeAlso Telegram Bot API Reference:
+ [Chat](https://core.telegram.org/bots/api#checklist)
+ */
+
+public final class TGChecklist: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case title
+        case titleEntities = "title_entities"
+        case tasks
+        case othersCanAddTasks = "others_can_add_tasks"
+        case othersCanMarkTasksAsDone = "others_can_mark_tasks_as_done"
+    }
+
+    /// Title of the checklist
+    public var title: String
+
+    /// Optional. Special entities that appear in the checklist title
+    public var titleEntities: [TGMessageEntity]?
+
+    /// List of tasks in the checklist
+    public var tasks: [TGChecklistTask]
+
+    /// Optional. True, if users other than the creator of the list can add tasks to the list
+    public var othersCanAddTasks: Bool?
+
+    /// Optional. True, if users other than the creator of the list can mark tasks as done or not done
+    public var othersCanMarkTasksAsDone: Bool?
+
+    init(title: String, titleEntities: [TGMessageEntity]? = nil, tasks: [TGChecklistTask], othersCanAddTasks: Bool? = nil, othersCanMarkTasksAsDone: Bool? = nil) {
+        self.title = title
+        self.titleEntities = titleEntities
+        self.tasks = tasks
+        self.othersCanAddTasks = othersCanAddTasks
+        self.othersCanMarkTasksAsDone = othersCanMarkTasksAsDone
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklistTask.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklistTask.swift
@@ -1,0 +1,41 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+/**
+ Describes a task in a checklist.
+
+ SeeAlso Telegram Bot API Reference:
+ [Chat](https://core.telegram.org/bots/api#checklisttask)
+ */
+
+public final class TGChecklistTask: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case id
+        case text
+        case textEntities = "text_entities"
+        case completedByUser = "completed_by_user"
+        case completionDate = "completion_date"
+    }
+
+    /// Unique identifier of the task
+    public var id: Int64
+
+    /// Text of the task
+    public var text: String
+
+    /// Optional. Special entities that appear in the task text
+    public var textEntities: [TGMessageEntity]?
+
+    /// Optional. User that completed the task; omitted if the task wasn't completed
+    public var completedByUser: TGUser?
+
+    /// Optional. Point in time (Unix timestamp) when the task was completed; 0 if the task wasn't completed
+    public var completionDate: Int
+
+    init(id: Int64, text: String, textEntities: [TGMessageEntity]? = nil, completedByUser: TGUser? = nil, completionDate: Int) {
+        self.id = id
+        self.text = text
+        self.textEntities = textEntities
+        self.completedByUser = completedByUser
+        self.completionDate = completionDate
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklistTasksAdded.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklistTasksAdded.swift
@@ -1,0 +1,26 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+/**
+ Describes a task in a checklist.
+
+ SeeAlso Telegram Bot API Reference:
+ [Chat](https://core.telegram.org/bots/api#checklisttasksdone)
+ */
+
+public final class TGChecklistTasksAdded: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case checklistMessage = "checklist_message"
+        case tasks
+    }
+
+    /// Optional. Message containing the checklist to which the tasks were added. Note that the Message object in this field will not contain the reply_to_message field even if it itself is a reply.
+    public var checklistMessage: TGMessage?
+
+    /// List of tasks added to the checklist
+    public var tasks: [TGChecklistTask]
+
+    init(checklistMessage: TGMessage? = nil, tasks: [TGChecklistTask]) {
+        self.checklistMessage = checklistMessage
+        self.tasks = tasks
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklistTasksDone.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGChecklistTasksDone.swift
@@ -1,0 +1,31 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+/**
+ Describes a task in a checklist.
+
+ SeeAlso Telegram Bot API Reference:
+ [Chat](https://core.telegram.org/bots/api#checklisttasksdone)
+ */
+
+public final class TGChecklistTasksDone: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case checklistMessage = "checklist_message"
+        case markedAsDoneTaskIds = "marked_as_done_task_ids"
+        case markedAsNotDoneTaskIds = "marked_as_not_done_task_ids"
+    }
+
+    /// Optional. Message containing the checklist whose tasks were marked as done or not done. Note that the Message object in this field will not contain the reply_to_message field even if it itself is a reply.
+    public var checklistMessage: TGMessage?
+
+    /// Optional. Identifiers of the tasks that were marked as done
+    public var markedAsDoneTaskIds: [Int64]?
+    
+    /// Optional. Identifiers of the tasks that were marked as not done
+    public var markedAsNotDoneTaskIds: [Int64]?
+
+    init(checklistMessage: TGMessage? = nil, markedAsDoneTaskIds: [Int64]? = nil, markedAsNotDoneTaskIds: [Int64]? = nil) {
+        self.checklistMessage = checklistMessage
+        self.markedAsDoneTaskIds = markedAsDoneTaskIds
+        self.markedAsNotDoneTaskIds = markedAsNotDoneTaskIds
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGExternalReplyInfo.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGExternalReplyInfo.swift
@@ -25,6 +25,7 @@ public final class TGExternalReplyInfo: Codable {
         case videoNote = "video_note"
         case voice = "voice"
         case hasMediaSpoiler = "has_media_spoiler"
+        case checklist
         case contact = "contact"
         case dice = "dice"
         case game = "game"
@@ -81,6 +82,9 @@ public final class TGExternalReplyInfo: Codable {
     /// Optional. True, if the message media is covered by a spoiler animation
     public var hasMediaSpoiler: Bool?
 
+    /// Optional. Message is a checklist
+    public var checklist: [TGChecklist]?
+
     /// Optional. Message is a shared contact, information about the contact
     public var contact: TGContact?
 
@@ -108,7 +112,7 @@ public final class TGExternalReplyInfo: Codable {
     /// Optional. Message is a venue, information about the venue
     public var venue: TGVenue?
 
-    public init (origin: TGMessageOrigin, chat: TGChat? = nil, messageId: Int? = nil, linkPreviewOptions: TGLinkPreviewOptions? = nil, animation: TGAnimation? = nil, audio: TGAudio? = nil, document: TGDocument? = nil, paidMedia: TGPaidMediaInfo? = nil, photo: [TGPhotoSize]? = nil, sticker: TGSticker? = nil, story: TGStory? = nil, video: TGVideo? = nil, videoNote: TGVideoNote? = nil, voice: TGVoice? = nil, hasMediaSpoiler: Bool? = nil, contact: TGContact? = nil, dice: TGDice? = nil, game: TGGame? = nil, giveaway: TGGiveaway? = nil, giveawayWinners: TGGiveawayWinners? = nil, invoice: TGInvoice? = nil, location: TGLocation? = nil, poll: TGPoll? = nil, venue: TGVenue? = nil) {
+    public init (origin: TGMessageOrigin, chat: TGChat? = nil, messageId: Int? = nil, linkPreviewOptions: TGLinkPreviewOptions? = nil, animation: TGAnimation? = nil, audio: TGAudio? = nil, document: TGDocument? = nil, paidMedia: TGPaidMediaInfo? = nil, photo: [TGPhotoSize]? = nil, sticker: TGSticker? = nil, story: TGStory? = nil, video: TGVideo? = nil, videoNote: TGVideoNote? = nil, voice: TGVoice? = nil, hasMediaSpoiler: Bool? = nil, checklist: [TGChecklist]? = nil, contact: TGContact? = nil, dice: TGDice? = nil, game: TGGame? = nil, giveaway: TGGiveaway? = nil, giveawayWinners: TGGiveawayWinners? = nil, invoice: TGInvoice? = nil, location: TGLocation? = nil, poll: TGPoll? = nil, venue: TGVenue? = nil) {
         self.origin = origin
         self.chat = chat
         self.messageId = messageId
@@ -124,6 +128,7 @@ public final class TGExternalReplyInfo: Codable {
         self.videoNote = videoNote
         self.voice = voice
         self.hasMediaSpoiler = hasMediaSpoiler
+        self.checklist = checklist
         self.contact = contact
         self.dice = dice
         self.game = game

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGInputChecklist.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGInputChecklist.swift
@@ -1,0 +1,38 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+/**
+ Describes a checklist to create.
+
+ SeeAlso Telegram Bot API Reference:
+ [Chat](https://core.telegram.org/bots/api#inputchecklist)
+ */
+
+public final class TGInputChecklist: Codable {
+  public enum CodingKeys: String, CodingKey {
+    case title = "title"
+    case parseMode = "parse_mode"
+    case titleEntities = "title_entities"
+    case tasks = "tasks"
+    case othersCanAddTasks = "others_can_add_tasks"
+    case othersCanMarkTasksAsDone = "others_can_mark_tasks_as_done"
+  }
+
+  
+  /// Title of the checklist; 1-255 characters after entities parsing
+  public var title: String
+  
+  /// Optional. Mode for parsing entities in the title. See formatting options for more details.
+  public var parseMode: TGParseMode?
+  
+  /// Optional. List of special entities that appear in the title, which can be specified instead of parse_mode. Currently, only bold, italic, underline, strikethrough, spoiler, and custom_emoji entities are allowed.
+  public var titleEntities: [TGMessageEntity]?
+  
+  /// List of 1-30 tasks in the checklist
+  public var tasks: [TGInputChecklistTask]
+
+  /// Optional. Pass True if other users can add tasks to the checklist
+  public var othersCanAddTasks: Bool?
+  
+  /// Optional. Pass True if other users can mark tasks as done or not done in the checklist
+  public var othersCanMarkTasksAsDone: Bool?
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGInputChecklistTask.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGInputChecklistTask.swift
@@ -1,0 +1,36 @@
+// Swift Telegram SDK - Telegram Bot Swift SDK.
+
+/**
+ Describes a task to add to a checklist.
+
+ SeeAlso Telegram Bot API Reference:
+ [Chat](https://core.telegram.org/bots/api#inputchecklisttask)
+ */
+
+public final class TGInputChecklistTask: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case id
+        case text
+        case parseMode = "parse_mode"
+        case textEntities = "text_entities"
+    }
+
+    /// Unique identifier of the task; must be positive and unique among all task identifiers currently present in the checklist
+    public var id: Int64
+    
+    /// Text of the task; 1-100 characters after entities parsing
+    public var text: String
+    
+    /// Optional. Mode for parsing entities in the text. See formatting options for more details.
+    public var parseMode: TGParseMode?
+
+    /// Optional. List of special entities that appear in the text, which can be specified instead of parse_mode. Currently, only bold, italic, underline, strikethrough, spoiler, and custom_emoji entities are allowed.
+    public var textEntities: [TGMessageEntity]?
+
+    init(id: Int64, text: String, parseMode: TGParseMode? = nil, textEntities: [TGMessageEntity]? = nil) {
+        self.id = id
+        self.text = text
+        self.parseMode = parseMode
+        self.textEntities = textEntities
+    }
+}

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGMessage.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGMessage.swift
@@ -51,6 +51,7 @@ public final class TGMessage: Codable {
         case captionEntities = "caption_entities"
         case showCaptionAboveMedia = "show_caption_above_media"
         case hasMediaSpoiler = "has_media_spoiler"
+        case checklist
         case contact = "contact"
         case dice = "dice"
         case game = "game"
@@ -82,6 +83,9 @@ public final class TGMessage: Codable {
         case proximityAlertTriggered = "proximity_alert_triggered"
         case boostAdded = "boost_added"
         case chatBackgroundSet = "chat_background_set"
+        case checklistTasksDone = "checklist_tasks_done"
+        case checklistTasksAdded = "checklist_tasks_added"
+        case directMessagePriceChanged = "direct_message_price_changed"
         case forumTopicCreated = "forum_topic_created"
         case forumTopicEdited = "forum_topic_edited"
         case forumTopicClosed = "forum_topic_closed"
@@ -224,6 +228,9 @@ public final class TGMessage: Codable {
     /// Optional. True, if the message media is covered by a spoiler animation
     public var hasMediaSpoiler: Bool?
 
+    /// Optional. Message is a checklist
+    public var checklist: [TGChecklist]?
+
     /// Optional. Message is a shared contact, information about the contact
     public var contact: TGContact?
 
@@ -317,6 +324,15 @@ public final class TGMessage: Codable {
     /// Optional. Service message: chat background set
     public var chatBackgroundSet: TGChatBackground?
 
+    /// Optional. Service message: some tasks in a checklist were marked as done or not done
+    public var checklistTasksDone: TGChecklistTasksDone?
+
+    /// Optional. Service message: tasks were added to a checklist 
+    public var checklistTasksAdded: TGChecklistTasksAdded?
+
+    /// Optional. Service message: the price for paid messages in the corresponding direct messages chat of a channel has changed
+    public var directMessagePriceChanged: TGDirectMessagePriceChanged?
+
     /// Optional. Service message: forum topic created
     public var forumTopicCreated: TGForumTopicCreated?
 
@@ -368,7 +384,7 @@ public final class TGMessage: Codable {
     /// Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
     public var replyMarkup: TGInlineKeyboardMarkup?
 
-    public init (messageId: Int, messageThreadId: Int? = nil, from: TGUser? = nil, senderChat: TGChat? = nil, senderBoostCount: Int? = nil, senderBusinessBot: TGUser? = nil, date: Int, businessConnectionId: String? = nil, chat: TGChat, forwardOrigin: TGMessageOrigin? = nil, isTopicMessage: Bool? = nil, isAutomaticForward: Bool? = nil, replyToMessage: TGMessage? = nil, externalReply: TGExternalReplyInfo? = nil, quote: TGTextQuote? = nil, replyToStory: TGStory? = nil, viaBot: TGUser? = nil, editDate: Int? = nil, hasProtectedContent: Bool? = nil, isFromOffline: Bool? = nil, mediaGroupId: String? = nil, authorSignature: String? = nil, paidStarCount: Int? = nil, text: String? = nil, entities: [TGMessageEntity]? = nil, linkPreviewOptions: TGLinkPreviewOptions? = nil, effectId: String? = nil, animation: TGAnimation? = nil, audio: TGAudio? = nil, document: TGDocument? = nil, paidMedia: TGPaidMediaInfo? = nil, photo: [TGPhotoSize]? = nil, sticker: TGSticker? = nil, story: TGStory? = nil, video: TGVideo? = nil, videoNote: TGVideoNote? = nil, voice: TGVoice? = nil, caption: String? = nil, captionEntities: [TGMessageEntity]? = nil, showCaptionAboveMedia: Bool? = nil, hasMediaSpoiler: Bool? = nil, contact: TGContact? = nil, dice: TGDice? = nil, game: TGGame? = nil, poll: TGPoll? = nil, venue: TGVenue? = nil, location: TGLocation? = nil, newChatMembers: [TGUser]? = nil, leftChatMember: TGUser? = nil, newChatTitle: String? = nil, newChatPhoto: [TGPhotoSize]? = nil, deleteChatPhoto: Bool? = nil, groupChatCreated: Bool? = nil, supergroupChatCreated: Bool? = nil, channelChatCreated: Bool? = nil, messageAutoDeleteTimerChanged: TGMessageAutoDeleteTimerChanged? = nil, migrateToChatId: Int64? = nil, migrateFromChatId: Int64? = nil, pinnedMessage: TGMaybeInaccessibleMessage? = nil, invoice: TGInvoice? = nil, successfulPayment: TGSuccessfulPayment? = nil, refundedPayment: TGRefundedPayment? = nil, usersShared: TGUsersShared? = nil, chatShared: TGChatShared? = nil, gift: TGGiftInfo? = nil, uniqueGift: TGUniqueGiftInfo? = nil, connectedWebsite: String? = nil, writeAccessAllowed: TGWriteAccessAllowed? = nil, passportData: TGPassportData? = nil, proximityAlertTriggered: TGProximityAlertTriggered? = nil, boostAdded: TGChatBoostAdded? = nil, chatBackgroundSet: TGChatBackground? = nil, forumTopicCreated: TGForumTopicCreated? = nil, forumTopicEdited: TGForumTopicEdited? = nil, forumTopicClosed: TGForumTopicClosed? = nil, forumTopicReopened: TGForumTopicReopened? = nil, generalForumTopicHidden: TGGeneralForumTopicHidden? = nil, generalForumTopicUnhidden: TGGeneralForumTopicUnhidden? = nil, giveawayCreated: TGGiveawayCreated? = nil, giveaway: TGGiveaway? = nil, giveawayWinners: TGGiveawayWinners? = nil, giveawayCompleted: TGGiveawayCompleted? = nil, paidMessagePriceChanged: TGPaidMessagePriceChanged? = nil, videoChatScheduled: TGVideoChatScheduled? = nil, videoChatStarted: TGVideoChatStarted? = nil, videoChatEnded: TGVideoChatEnded? = nil, videoChatParticipantsInvited: TGVideoChatParticipantsInvited? = nil, webAppData: TGWebAppData? = nil, replyMarkup: TGInlineKeyboardMarkup? = nil) {
+    public init (messageId: Int, messageThreadId: Int? = nil, from: TGUser? = nil, senderChat: TGChat? = nil, senderBoostCount: Int? = nil, senderBusinessBot: TGUser? = nil, date: Int, businessConnectionId: String? = nil, chat: TGChat, forwardOrigin: TGMessageOrigin? = nil, isTopicMessage: Bool? = nil, isAutomaticForward: Bool? = nil, replyToMessage: TGMessage? = nil, externalReply: TGExternalReplyInfo? = nil, quote: TGTextQuote? = nil, replyToStory: TGStory? = nil, viaBot: TGUser? = nil, editDate: Int? = nil, hasProtectedContent: Bool? = nil, isFromOffline: Bool? = nil, mediaGroupId: String? = nil, authorSignature: String? = nil, paidStarCount: Int? = nil, text: String? = nil, entities: [TGMessageEntity]? = nil, linkPreviewOptions: TGLinkPreviewOptions? = nil, effectId: String? = nil, animation: TGAnimation? = nil, audio: TGAudio? = nil, document: TGDocument? = nil, paidMedia: TGPaidMediaInfo? = nil, photo: [TGPhotoSize]? = nil, sticker: TGSticker? = nil, story: TGStory? = nil, video: TGVideo? = nil, videoNote: TGVideoNote? = nil, voice: TGVoice? = nil, caption: String? = nil, captionEntities: [TGMessageEntity]? = nil, showCaptionAboveMedia: Bool? = nil, hasMediaSpoiler: Bool? = nil, checklist: [TGChecklist]? = nil, contact: TGContact? = nil, dice: TGDice? = nil, game: TGGame? = nil, poll: TGPoll? = nil, venue: TGVenue? = nil, location: TGLocation? = nil, newChatMembers: [TGUser]? = nil, leftChatMember: TGUser? = nil, newChatTitle: String? = nil, newChatPhoto: [TGPhotoSize]? = nil, deleteChatPhoto: Bool? = nil, groupChatCreated: Bool? = nil, supergroupChatCreated: Bool? = nil, channelChatCreated: Bool? = nil, messageAutoDeleteTimerChanged: TGMessageAutoDeleteTimerChanged? = nil, migrateToChatId: Int64? = nil, migrateFromChatId: Int64? = nil, pinnedMessage: TGMaybeInaccessibleMessage? = nil, invoice: TGInvoice? = nil, successfulPayment: TGSuccessfulPayment? = nil, refundedPayment: TGRefundedPayment? = nil, usersShared: TGUsersShared? = nil, chatShared: TGChatShared? = nil, gift: TGGiftInfo? = nil, uniqueGift: TGUniqueGiftInfo? = nil, connectedWebsite: String? = nil, writeAccessAllowed: TGWriteAccessAllowed? = nil, passportData: TGPassportData? = nil, proximityAlertTriggered: TGProximityAlertTriggered? = nil, boostAdded: TGChatBoostAdded? = nil, chatBackgroundSet: TGChatBackground? = nil, checklistTasksDone: TGChecklistTasksDone? = nil, checklistTasksAdded: TGChecklistTasksAdded? = nil, directMessagePriceChanged: TGDirectMessagePriceChanged? = nil, forumTopicCreated: TGForumTopicCreated? = nil, forumTopicEdited: TGForumTopicEdited? = nil, forumTopicClosed: TGForumTopicClosed? = nil, forumTopicReopened: TGForumTopicReopened? = nil, generalForumTopicHidden: TGGeneralForumTopicHidden? = nil, generalForumTopicUnhidden: TGGeneralForumTopicUnhidden? = nil, giveawayCreated: TGGiveawayCreated? = nil, giveaway: TGGiveaway? = nil, giveawayWinners: TGGiveawayWinners? = nil, giveawayCompleted: TGGiveawayCompleted? = nil, paidMessagePriceChanged: TGPaidMessagePriceChanged? = nil, videoChatScheduled: TGVideoChatScheduled? = nil, videoChatStarted: TGVideoChatStarted? = nil, videoChatEnded: TGVideoChatEnded? = nil, videoChatParticipantsInvited: TGVideoChatParticipantsInvited? = nil, webAppData: TGWebAppData? = nil, replyMarkup: TGInlineKeyboardMarkup? = nil) {
         self.messageId = messageId
         self.messageThreadId = messageThreadId
         self.from = from
@@ -410,6 +426,7 @@ public final class TGMessage: Codable {
         self.captionEntities = captionEntities
         self.showCaptionAboveMedia = showCaptionAboveMedia
         self.hasMediaSpoiler = hasMediaSpoiler
+        self.checklist = checklist
         self.contact = contact
         self.dice = dice
         self.game = game
@@ -441,6 +458,9 @@ public final class TGMessage: Codable {
         self.proximityAlertTriggered = proximityAlertTriggered
         self.boostAdded = boostAdded
         self.chatBackgroundSet = chatBackgroundSet
+        self.checklistTasksDone = checklistTasksDone
+        self.checklistTasksAdded = checklistTasksAdded
+        self.directMessagePriceChanged = directMessagePriceChanged
         self.forumTopicCreated = forumTopicCreated
         self.forumTopicEdited = forumTopicEdited
         self.forumTopicClosed = forumTopicClosed

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGOwnedGiftUnique.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGOwnedGiftUnique.swift
@@ -18,6 +18,7 @@ public final class TGOwnedGiftUnique: Codable {
         case isSaved = "is_saved"
         case canBeTransferred = "can_be_transferred"
         case transferStarCount = "transfer_star_count"
+        case nextTransferDate = "next_transfer_date"
     }
 
     /// Type of the gift, always “unique”
@@ -44,7 +45,10 @@ public final class TGOwnedGiftUnique: Codable {
     /// Optional. Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift
     public var transferStarCount: Int?
 
-    public init (type: TGOwnedGiftUniqueType, gift: TGUniqueGift, ownedGiftId: String? = nil, senderUser: TGUser? = nil, sendDate: Int, isSaved: Bool? = nil, canBeTransferred: Bool? = nil, transferStarCount: Int? = nil) {
+    /// Optional. Point in time (Unix timestamp) when the gift can be transferred. If it is in the past, then the gift can be transferred now
+    public var nextTransferDate: Int?
+
+    public init (type: TGOwnedGiftUniqueType, gift: TGUniqueGift, ownedGiftId: String? = nil, senderUser: TGUser? = nil, sendDate: Int, isSaved: Bool? = nil, canBeTransferred: Bool? = nil, transferStarCount: Int? = nil, nextTransferDate: Int? = nil) {
         self.type = type
         self.gift = gift
         self.ownedGiftId = ownedGiftId
@@ -53,5 +57,6 @@ public final class TGOwnedGiftUnique: Codable {
         self.isSaved = isSaved
         self.canBeTransferred = canBeTransferred
         self.transferStarCount = transferStarCount
+        self.nextTransferDate = nextTransferDate
     }
 }

--- a/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGUniqueGiftInfo.swift
+++ b/Sources/SwiftTelegramSdk/Bot/Telegram/Models/TGUniqueGiftInfo.swift
@@ -12,15 +12,20 @@ public final class TGUniqueGiftInfo: Codable {
     public enum CodingKeys: String, CodingKey {
         case gift = "gift"
         case origin = "origin"
+        case lastResaleStarCount = "last_resale_star_count"
         case ownedGiftId = "owned_gift_id"
         case transferStarCount = "transfer_star_count"
+        case nextTransferDate = "next_transfer_date"
     }
 
     /// Information about the gift
     public var gift: TGUniqueGift
 
-    /// Origin of the gift. Currently, either “upgrade” or “transfer”
+    /// Origin of the gift. Currently, either “upgrade” for gifts upgraded from regular gifts, “transfer” for gifts transferred from other users or channels, or “resale” for gifts bought from other users
     public var origin: String
+
+    /// Optional. For gifts bought from other users, the price paid for the gift
+    public var lastResaleStarCount: Int?
 
     /// Optional. Unique identifier of the received gift for the bot; only present for gifts received on behalf of business accounts
     public var ownedGiftId: String?
@@ -28,10 +33,15 @@ public final class TGUniqueGiftInfo: Codable {
     /// Optional. Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift
     public var transferStarCount: Int?
 
-    public init (gift: TGUniqueGift, origin: String, ownedGiftId: String? = nil, transferStarCount: Int? = nil) {
+    /// Optional. Point in time (Unix timestamp) when the gift can be transferred. If it is in the past, then the gift can be transferred now
+    public var nextTransferDate: Int?
+
+    public init (gift: TGUniqueGift, origin: String, lastResaleStarCount: Int? = nil, ownedGiftId: String? = nil, transferStarCount: Int? = nil, nextTransferDate: Int? = nil) {
         self.gift = gift
         self.origin = origin
+        self.lastResaleStarCount = lastResaleStarCount
         self.ownedGiftId = ownedGiftId
         self.transferStarCount = transferStarCount
+        self.nextTransferDate = nextTransferDate
     }
 }


### PR DESCRIPTION
This PR applies the latest update in the Telegram Bot API. You can read more about the changes here: https://core.telegram.org/bots/api#july-3-2025

<details>
<summary>List of changes</summary>
## July 3, 2025
## Bot API 9.1

### Checklists

- Added the class [ChecklistTask](https://core.telegram.org/bots/api#checklisttask) representing a task in a checklist.
- Added the class [Checklist](https://core.telegram.org/bots/api#checklist) representing a checklist.
- Added the class [InputChecklistTask](https://core.telegram.org/bots/api#inputchecklisttask) representing a task to add to a checklist.
- Added the class [InputChecklist](https://core.telegram.org/bots/api#inputchecklist) representing a checklist to create.
- Added the field checklist to the classes [Message](https://core.telegram.org/bots/api#message) and [ExternalReplyInfo](https://core.telegram.org/bots/api#externalreplyinfo), describing a checklist in a message.
- Added the class [ChecklistTasksDone](https://core.telegram.org/bots/api#checklisttasksdone) and the field checklist_tasks_done to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about status changes for tasks in a checklist (i.e., marked as done/not done).
- Added the class [ChecklistTasksAdded](https://core.telegram.org/bots/api#checklisttasksadded) and the field checklist_tasks_added to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about the addition of new tasks to a checklist.
- Added the method [sendChecklist](https://core.telegram.org/bots/api#sendchecklist), allowing bots to send a checklist on behalf of a business account.
- Added the method [editMessageChecklist](https://core.telegram.org/bots/api#editmessagechecklist), allowing bots to edit a checklist on behalf of a business account.

### Gifts

- Added the field next_transfer_date to the classes [OwnedGiftUnique](https://core.telegram.org/bots/api#ownedgiftunique) and [UniqueGiftInfo](https://core.telegram.org/bots/api#uniquegiftinfo).
- Added the field last_resale_star_count to the class [UniqueGiftInfo](https://core.telegram.org/bots/api#uniquegiftinfo).
- Added “resale” as the possible value of the field origin in the class [UniqueGiftInfo](https://core.telegram.org/bots/api#uniquegiftinfo).

### General

- Increased the maximum number of options in a poll to 12.
- Added the method [getMyStarBalance](https://core.telegram.org/bots/api#getmystarbalance), allowing bots to get their current balance of Telegram Stars.
- Added the class [DirectMessagePriceChanged](https://core.telegram.org/bots/api#directmessagepricechanged) and the field direct_message_price_changed to the class [Message](https://core.telegram.org/bots/api#message), describing a service message about a price change for direct messages sent to the channel chat.
- Added the method hideKeyboard to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
</details>